### PR TITLE
MOB-1337 update sdk from 25 to 28 to match our project requirements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     compile "com.facebook.react:react-native:+"  // From node_modules
-    compile 'com.android.support:customtabs:25.0.1'
+    compile 'com.android.support:customtabs:28.0.0'
     compile ('com.github.droibit.customtabslauncher:launcher:1.0.8') {
         exclude module: 'customtabs'
     }


### PR DESCRIPTION
using a forked version of this library to keep it up to date with more recent version of react-native.

Updated sdk to 28